### PR TITLE
add support for riscv32imac-esp-espidf and riscv32imc-esp-espidf

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,22 @@ presence = []
 sudo apt-get install gcc-arm-none-eabi
 ```
 
-ESP targets require ESP toolchains, installable via espup (https://github.com/esp-rs/espup).
+ESP targets require ESP toolchains, install via the VSCode extension from espressif.
+Before you can build a121-sys, you need to set the environment variables by sourcing the applicable SDK, i.e.:
+```
+. ~/esp/v5.2.3/esp-idf/export.sh
+```
+Then make sure that the following gives you the correct sysroot path:
+```
+riscv32-esp-elf-gcc -print-sysroot
+```
 
 ## Supported Targets
 
 Support is dependent on the Acconeer A121 Static Library's availability:
 
 - arm-none-eabihf (gcc, armcc, armclang)
-- esp xtensa and riscv
+- esp riscv
 
 ## Getting Started
 

--- a/build/bindings.rs
+++ b/build/bindings.rs
@@ -17,7 +17,7 @@ pub fn generate_bindings(rss_path: &Path) -> Result<()> {
 
     // Get GCC sysroot
     let sysroot = get_gcc_sysroot()?;
-
+    
     // Base bindgen configuration
     let mut builder = Builder::default()
         .use_core()
@@ -58,7 +58,8 @@ pub fn generate_bindings(rss_path: &Path) -> Result<()> {
         // Add sysroot includes
         builder = builder
             .clang_arg(format!("--sysroot={}", sysroot))
-            .clang_arg(format!("-I{}/include", sysroot));
+            .clang_arg(format!("-I{}/include", sysroot))
+            .clang_arg(format!("-I{}/riscv32-esp-elf/include", sysroot));
 
         // Add GCC includes
         if let Ok(output) = Command::new("riscv32-esp-elf-gcc")


### PR DESCRIPTION
Coming back to running a121-rs on an esp32c3/esp32c6 - and seems some things changed in the meantime, especially with this new a121-sys crate.  I extended the bindings generation to set the correct cross-compilation target (`riscv32-esp-elf`), and to also automatically find the sysroot and include directories for the `riscv32imac-esp-espidf` and `riscv32imc-esp-espidf` targets, which are the c3 and c6 in combination with the std environment (via https://github.com/esp-rs/esp-idf-svc).

Will mark this as ready to merge once I have confirmed that this runs successfully on the c3/c6. 

Still having a couple issues until we get there:
- [x] `riscv32-esp-elf-gcc` is no longer installed by espup, and instead is only present in the .embuild folder of the main application crate (i.e. `.embuild/espressif/tools/riscv32-esp-elf/esp-13.2.0_20240530/riscv32-esp-elf/bin`) or in an installation done by the VSCode extension (i.e. `~/.espressif/tools/riscv32-esp-elf/...`  &rarr; I added a note to the README about it. A workaround to find the sysroot due to a bug in esp-idf is also added.
- [x]  [SpiDeviceDriver](https://github.com/esp-rs/esp-idf-hal/blob/3972bf35bcd81e9eb866ed342d2ad5cd584aff95/examples/spi_st7789.rs#L53) (from esp-idf-hal) doesn´t seem to be compatible with what the Radar's new method seems to expect &rarr; I have refactored a121-rs to not need an SPI adapter at all and work with the normal embedded_hal traits, a separate PR will follow
